### PR TITLE
Add motivational rewards and persist timer state

### DIFF
--- a/app/src/main/java/com/bpareja/pomodorotec/MainActivity.kt
+++ b/app/src/main/java/com/bpareja/pomodorotec/MainActivity.kt
@@ -35,6 +35,11 @@ class MainActivity : ComponentActivity() {
 
         }
 
+    override fun onStop() {
+        super.onStop()
+        viewModel.persistState()
+    }
+
 
     private fun createNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/app/src/main/java/com/bpareja/pomodorotec/pomodoro/PomodoroUI.kt
+++ b/app/src/main/java/com/bpareja/pomodorotec/pomodoro/PomodoroUI.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.LinearProgressIndicator
@@ -64,6 +65,8 @@ fun PomodoroScreen(viewModel: PomodoroViewModel = viewModel()) {
     val isSkipBreakButtonVisible by viewModel.isSkipBreakButtonVisible.observeAsState(false) // Visibilidad del botón saltar
     var isDarkTheme by remember { mutableStateOf(false) }             // Control del tema oscuro
     val progress by viewModel.progress.observeAsState(0f)             // Progreso de la barra (0f a 1f)
+    val rewardToShow by viewModel.rewardToShow.observeAsState()
+    val completedSessions by viewModel.completedSessions.observeAsState(0)
 
     // Contenedor principal con tema
     PomodoroTecTheme(darkTheme = isDarkTheme) {
@@ -156,6 +159,13 @@ fun PomodoroScreen(viewModel: PomodoroViewModel = viewModel()) {
                 )
 
                 Spacer(modifier = Modifier.height(16.dp))
+                Text(
+                    text = "Sesiones completadas: $completedSessions",
+                    fontSize = 16.sp,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(modifier = Modifier.height(8.dp))
 
                 // Contenedor con padding y sombra para la barra de progreso
                 Box(
@@ -248,6 +258,12 @@ fun PomodoroScreen(viewModel: PomodoroViewModel = viewModel()) {
             ) {
                 Text("Actualizar", color = Color(0xFFB22222), fontSize = 18.sp, fontWeight = FontWeight.Bold)
             }
+        }
+        rewardToShow?.let { reward ->
+            MotivationRewardDialog(
+                reward = reward,
+                onDismiss = { viewModel.acknowledgeReward() }
+            )
         }
     }
 }
@@ -348,5 +364,48 @@ fun AnimatedWave(
         }
         drawPath(path = path, color = color.copy(alpha = 0.6f))
     }
+}
+
+@Composable
+fun MotivationRewardDialog(
+    reward: MotivationReward,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            Button(onClick = onDismiss) {
+                Text("Seguir enfocando", fontWeight = FontWeight.Bold)
+            }
+        },
+        title = {
+            Text(
+                text = reward.headline,
+                fontSize = 22.sp,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        },
+        text = {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Image(
+                    painter = painterResource(id = reward.imageRes),
+                    contentDescription = reward.headline,
+                    modifier = Modifier
+                        .size(160.dp)
+                        .padding(bottom = 12.dp)
+                )
+                Text(
+                    text = reward.message,
+                    textAlign = TextAlign.Center,
+                    fontSize = 18.sp
+                )
+            }
+        }
+    )
 }
 

--- a/app/src/main/java/com/bpareja/pomodorotec/pomodoro/PomodoroViewModel.kt
+++ b/app/src/main/java/com/bpareja/pomodorotec/pomodoro/PomodoroViewModel.kt
@@ -42,7 +42,7 @@ class PomodoroViewModel(application: Application) : AndroidViewModel(application
     companion object {
         internal var instance: PomodoroViewModel? = null
 
-        private const val REWARD_THRESHOLD = 4
+        private const val REWARD_THRESHOLD = 1
         private const val KEY_HAS_STATE = "has_state"
         private const val KEY_PHASE = "phase"
         private const val KEY_TIME_REMAINING = "time_remaining"

--- a/app/src/main/java/com/bpareja/pomodorotec/pomodoro/PomodoroViewModel.kt
+++ b/app/src/main/java/com/bpareja/pomodorotec/pomodoro/PomodoroViewModel.kt
@@ -9,18 +9,26 @@ import android.graphics.BitmapFactory
 import android.graphics.Color
 import android.media.RingtoneManager
 import android.os.CountDownTimer
+import android.os.SystemClock
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.annotation.DrawableRes
 import com.bpareja.pomodorotec.MainActivity
 import com.bpareja.pomodorotec.PomodoroReceiver
 import com.bpareja.pomodorotec.R
 import com.bpareja.pomodorotec.utils.DataSyncManager
 import android.appwidget.AppWidgetManager
 import android.content.ComponentName
+
+data class MotivationReward(
+    @DrawableRes val imageRes: Int,
+    val message: String,
+    val headline: String
+)
 
 enum class Phase {
     FOCUS, BREAK
@@ -33,6 +41,17 @@ class PomodoroViewModel(application: Application) : AndroidViewModel(application
     // Singleton para acceder al ViewModel desde el BroadcastReceiver
     companion object {
         internal var instance: PomodoroViewModel? = null
+
+        private const val REWARD_THRESHOLD = 4
+        private const val KEY_HAS_STATE = "has_state"
+        private const val KEY_PHASE = "phase"
+        private const val KEY_TIME_REMAINING = "time_remaining"
+        private const val KEY_TOTAL_TIME = "total_time"
+        private const val KEY_IS_RUNNING = "is_running"
+        private const val KEY_SAVED_AT = "saved_at"
+        private const val KEY_IS_BREAK_SKIPPABLE = "skip_visible"
+        private const val KEY_COMPLETED_SESSIONS = "completed_sessions"
+
         fun skipBreak() {
             instance?.startFocusSession()  // Saltar el descanso y comenzar sesión de concentración
         }
@@ -56,11 +75,37 @@ class PomodoroViewModel(application: Application) : AndroidViewModel(application
     private val _progress = MutableLiveData(0f) // Progreso (0-1)
     val progress: LiveData<Float> = _progress
 
+    // Estados para recompensas motivacionales
+    private val _completedSessions = MutableLiveData(0)
+    val completedSessions: LiveData<Int> = _completedSessions
+
+    private val _rewardToShow = MutableLiveData<MotivationReward?>(null)
+    val rewardToShow: LiveData<MotivationReward?> = _rewardToShow
+
     // Variables de control del timer
     private var countDownTimer: CountDownTimer? = null
 
     private var totalTimeInMillis: Long = 25 * 60 * 1000L // Tiempo total (25 min)
     private var timeRemainingInMillis: Long = 25 * 60 * 1000L // Tiempo inicial para FOCUS
+
+    private val statePrefs = context.getSharedPreferences("pomodoro_state_prefs", Context.MODE_PRIVATE)
+
+    private val motivationalPhrases = listOf(
+        "¡Increíble! Llevas %d sesiones enfocadas. Mantén el ritmo.",
+        "Tu constancia paga resultados. %d sesiones completadas.",
+        "%d bloques de concentración. ¡Estás imparable!",
+        "Respira y sonríe: %d sesiones al hilo. ¡Grande!"
+    )
+
+    private val motivationalImages = listOf(
+        R.drawable.focus_image,
+        R.drawable.break_image,
+        R.drawable.pomodoro
+    )
+
+    init {
+        restoreSavedState()
+    }
 
     // ----------- FUNCIONES PRINCIPALES ------------
 
@@ -74,6 +119,7 @@ class PomodoroViewModel(application: Application) : AndroidViewModel(application
         _isSkipBreakButtonVisible.value = false
         showNotification("Inicio de Concentración", "La sesión de concentración ha comenzado.")
         startTimer()
+        persistState()
     }
 
     private fun startBreakSession() {
@@ -107,7 +153,10 @@ class PomodoroViewModel(application: Application) : AndroidViewModel(application
                 _isRunning.value = false
                 _progress.value = 1f
                 when (_currentPhase.value) {
-                    Phase.FOCUS -> startBreakSession()
+                    Phase.FOCUS -> {
+                        handleFocusSessionCompleted()
+                        startBreakSession()
+                    }
                     Phase.BREAK -> startFocusSession()
                     null -> {}
                 }
@@ -134,7 +183,7 @@ class PomodoroViewModel(application: Application) : AndroidViewModel(application
     fun pauseTimer() {
         countDownTimer?.cancel()
         _isRunning.value = false
-        // Actualizar notificación si quieres aquí
+        persistState()
     }
 
     fun resetTimer() {
@@ -148,6 +197,7 @@ class PomodoroViewModel(application: Application) : AndroidViewModel(application
         _isSkipBreakButtonVisible.value = false
         // Actualizar widget aquí también si quieres
         updateWidgetData()
+        clearSavedState()
     }
 
     // -------------- ACTUALIZACIÓN DE WIDGET -----------------
@@ -168,6 +218,90 @@ class PomodoroViewModel(application: Application) : AndroidViewModel(application
             .getAppWidgetIds(ComponentName(context, com.bpareja.pomodorotec.PomodoroWidgetProvider::class.java))
         intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
         context.sendBroadcast(intent)
+    }
+
+    fun acknowledgeReward() {
+        _rewardToShow.value = null
+    }
+
+    fun persistState() {
+        val phaseName = _currentPhase.value?.name ?: Phase.FOCUS.name
+        statePrefs.edit().apply {
+            putBoolean(KEY_HAS_STATE, true)
+            putString(KEY_PHASE, phaseName)
+            putLong(KEY_TIME_REMAINING, timeRemainingInMillis)
+            putLong(KEY_TOTAL_TIME, totalTimeInMillis)
+            putBoolean(KEY_IS_RUNNING, _isRunning.value ?: false)
+            putLong(KEY_SAVED_AT, SystemClock.elapsedRealtime())
+            putBoolean(KEY_IS_BREAK_SKIPPABLE, _isSkipBreakButtonVisible.value ?: false)
+            putInt(KEY_COMPLETED_SESSIONS, _completedSessions.value ?: 0)
+            apply()
+        }
+    }
+
+    private fun restoreSavedState() {
+        if (!statePrefs.getBoolean(KEY_HAS_STATE, false)) {
+            return
+        }
+        val savedPhase = runCatching { Phase.valueOf(statePrefs.getString(KEY_PHASE, Phase.FOCUS.name) ?: Phase.FOCUS.name) }.getOrDefault(Phase.FOCUS)
+        val savedTimeRemaining = statePrefs.getLong(KEY_TIME_REMAINING, 25 * 60 * 1000L)
+        val savedTotal = statePrefs.getLong(KEY_TOTAL_TIME, 25 * 60 * 1000L)
+        val wasRunning = statePrefs.getBoolean(KEY_IS_RUNNING, false)
+        val savedAt = statePrefs.getLong(KEY_SAVED_AT, SystemClock.elapsedRealtime())
+        val savedSkipVisible = statePrefs.getBoolean(KEY_IS_BREAK_SKIPPABLE, false)
+        val sessions = statePrefs.getInt(KEY_COMPLETED_SESSIONS, 0)
+
+        var adjustedTime = savedTimeRemaining
+        if (wasRunning) {
+            val elapsed = SystemClock.elapsedRealtime() - savedAt
+            adjustedTime -= elapsed
+        }
+
+        if (adjustedTime <= 0L && wasRunning) {
+            when (savedPhase) {
+                Phase.FOCUS -> {
+                    handleFocusSessionCompleted()
+                    startBreakSession()
+                }
+                Phase.BREAK -> startFocusSession()
+            }
+            return
+        }
+
+        timeRemainingInMillis = adjustedTime
+        totalTimeInMillis = savedTotal
+        _currentPhase.value = savedPhase
+        _timeLeft.value = formatTime(adjustedTime)
+        _progress.value = 1f - (adjustedTime.toFloat() / totalTimeInMillis.toFloat())
+        _isSkipBreakButtonVisible.value = savedSkipVisible
+        _completedSessions.value = sessions
+
+        if (wasRunning) {
+            startTimer()
+        }
+    }
+
+    private fun clearSavedState() {
+        statePrefs.edit().clear().apply()
+    }
+
+    private fun handleFocusSessionCompleted() {
+        val newCount = (_completedSessions.value ?: 0) + 1
+        _completedSessions.value = newCount
+        if (newCount % REWARD_THRESHOLD == 0) {
+            _rewardToShow.value = MotivationReward(
+                imageRes = motivationalImages.random(),
+                message = motivationalPhrases.random().format(newCount),
+                headline = "¡Recompensa desbloqueada!"
+            )
+        }
+        persistState()
+    }
+
+    private fun formatTime(millis: Long): String {
+        val minutes = (millis / 1000) / 60
+        val seconds = (millis / 1000) % 60
+        return String.format("%02d:%02d", minutes, seconds)
     }
 
     // ----------------- NOTIFICACIÓN AVANZADA ------------------------


### PR DESCRIPTION
Descripción de cambios:

Recompensa motivacional: Se agregó lógica en el ViewModel para mostrar mensajes de ánimo al completar un pomodoro.

Persistencia automática: Se implementó el guardado del estado del timer para que no se reinicie al cerrar la app.

Pruebas realizadas:

Probé completando 4 ciclos y apareció el mensaje.

Cerré la app a la mitad del conteo y al abrirla seguía donde estaba.